### PR TITLE
Add daily rotation of logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "adlu-proxy"
-version = "1.1.0-alpha.1"
+version = "1.1.0-rc.1"
 dependencies = [
  "adlu-base",
  "adlu-parse",
@@ -1165,9 +1165,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1704,9 +1704,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.24.0+1.1.1s"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
 dependencies = [
  "cc",
 ]
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "adlu-base",
  "adlu-parse",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "eyre",
  "glob",
  "shellexpand",
@@ -64,13 +64,14 @@ dependencies = [
 
 [[package]]
 name = "adlu-proxy"
-version = "1.0.0"
+version = "1.1.0-alpha.1"
 dependencies = [
  "adlu-base",
  "adlu-parse",
+ "anyhow",
  "bytes",
  "chrono",
- "clap",
+ "clap 4.0.18",
  "config",
  "csv",
  "ctrlc",
@@ -151,22 +152,32 @@ checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
+ "async-lock",
  "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
  "slab",
  "socket2",
  "waker-fn",
  "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -327,9 +338,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 dependencies = [
  "jobserver",
 ]
@@ -372,13 +383,28 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.18",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -395,10 +421,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1154,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1612,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1698,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "parking"

--- a/adlu-proxy/Cargo.toml
+++ b/adlu-proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "adlu-proxy"
 authors = ["Daniel Brotsky <dan@clickonetwo.io>"]
 description = "A protocol-aware, caching, store/forward reverse proxy for Adobe desktop licensing servers"
 license = "AGPLv3"
-version = "1.1.0-alpha.1"
+version = "1.1.0-rc.1"
 edition = "2021"
 
 [features]

--- a/adlu-proxy/Cargo.toml
+++ b/adlu-proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "adlu-proxy"
 authors = ["Daniel Brotsky <dan@clickonetwo.io>"]
 description = "A protocol-aware, caching, store/forward reverse proxy for Adobe desktop licensing servers"
 license = "AGPLv3"
-version = "1.0.0"
+version = "1.1.0-alpha.1"
 edition = "2021"
 
 [features]
@@ -12,9 +12,10 @@ parse_responses = ["adlu-parse/parse-reponses"]
 [dependencies]
 adlu-base = { path = "../adlu-base" }
 adlu-parse = { path = "../adlu-parse" }
+anyhow = "1"    # needed for log4rs trigger definition
 bytes = "1.1"
 chrono = "0.4"
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 config = "0.13"
 ctrlc = { version = "3.1", features = ["termination"] }
 csv = "1"

--- a/adlu-proxy/src/cli.rs
+++ b/adlu-proxy/src/cli.rs
@@ -43,7 +43,10 @@ pub struct ProxyArgs {
 /// Proxy commands
 pub enum Command {
     /// Interactively create the config file
-    Configure,
+    Configure {
+        #[clap(short, long)]
+        repair: bool,
+    },
     /// Start the proxy server
     Serve {
         #[clap(short, long)]

--- a/adlu-proxy/src/cli.rs
+++ b/adlu-proxy/src/cli.rs
@@ -52,7 +52,7 @@ pub enum Command {
         /// Overrides the config file setting.
         mode: Option<String>,
 
-        #[clap(long, parse(try_from_str))]
+        #[clap(long, value_parser=clap::builder::BoolishValueParser::new())]
         /// Enable SSL? (true or false).
         /// Overrides the config file setting.
         ssl: Option<bool>,

--- a/adlu-proxy/src/lib.rs
+++ b/adlu-proxy/src/lib.rs
@@ -39,9 +39,7 @@ pub async fn run(
     debug!("Loaded config: {:?}", &settings);
     let cache = cache::connect(&settings.proxy.db_path).await?;
     let result = match args.cmd {
-        Command::Configure => {
-            settings::update_config_file(Some(&settings), &args.config_file)
-        }
+        Command::Configure { .. } => settings::update_config_file(Some(&settings), &args),
         Command::Serve { .. } => {
             if settings.proxy.ssl {
                 proxy::serve_incoming_https_requests(&settings, &cache, stop_signal).await

--- a/adlu-proxy/src/logging.rs
+++ b/adlu-proxy/src/logging.rs
@@ -18,20 +18,23 @@ released.  That license is reproduced here in the LICENSE-MIT file.
 */
 use eyre::{eyre, Result, WrapErr};
 use log::LevelFilter;
-use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
-use log4rs::append::rolling_file::policy::compound::trigger::size::SizeTrigger;
-use log4rs::append::rolling_file::policy::compound::CompoundPolicy;
-use log4rs::append::rolling_file::RollingFileAppender;
 use log4rs::{
     append::{
         console::{ConsoleAppender, Target},
         file::FileAppender,
+        rolling_file::{
+            policy::compound::{
+                roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger,
+                trigger::Trigger, CompoundPolicy,
+            },
+            LogFile, RollingFileAppender,
+        },
     },
     config::{Appender, Config, Root},
     encode::pattern::PatternEncoder,
 };
 
-use crate::settings::{LogDestination, LogLevel, Logging};
+use crate::settings::{LogDestination, LogLevel, LogRotationType, Logging};
 
 pub fn init(logging: &Logging) -> Result<()> {
     let pattern = "{d([%Y-%m-%d][%H:%M:%S])}[{t}][{l}] {m}{n}";
@@ -47,32 +50,36 @@ pub fn init(logging: &Logging) -> Result<()> {
                     .build(),
             ),
         )
-    } else if logging.rotate_size_kb > 0 {
-        let window_size = logging.rotate_count;
-        let pattern = roll_pattern(&logging.file_path);
-        let fixed_window_roller = FixedWindowRoller::builder()
-            .build(&pattern, window_size)
-            .map_err(|err| eyre!("Can't build log rotation config: {:?}", err))?;
-        let size_limit = 1024 * logging.rotate_size_kb;
-        let size_trigger = SizeTrigger::new(size_limit as u64);
-        let compound_policy =
-            CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller));
-        Appender::builder().build(
-            "logger",
-            Box::new(
-                RollingFileAppender::builder()
-                    .encoder(Box::new(encoder))
-                    .build(&logging.file_path, Box::new(compound_policy))
-                    .wrap_err("Can't create log file configuration")?,
-            ),
-        )
-    } else {
+    } else if let LogRotationType::None = logging.rotate_type {
         Appender::builder().build(
             "logger",
             Box::new(
                 FileAppender::builder()
                     .encoder(Box::new(encoder))
                     .build(&logging.file_path)
+                    .wrap_err("Can't create log file configuration")?,
+            ),
+        )
+    } else {
+        let window_size = logging.rotate_count;
+        let pattern = roll_pattern(&logging.file_path);
+        let fixed_window_roller = FixedWindowRoller::builder()
+            .build(&pattern, window_size)
+            .map_err(|err| eyre!("Can't build log rotation config: {:?}", err))?;
+        let compound_policy = if let LogRotationType::Sized = logging.rotate_type {
+            let size_limit = 1024 * logging.max_size_kb;
+            let size_trigger = SizeTrigger::new(size_limit as u64);
+            CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller))
+        } else {
+            let daily_trigger = DailyTrigger::new();
+            CompoundPolicy::new(Box::new(daily_trigger), Box::new(fixed_window_roller))
+        };
+        Appender::builder().build(
+            "logger",
+            Box::new(
+                RollingFileAppender::builder()
+                    .encoder(Box::new(encoder))
+                    .build(&logging.file_path, Box::new(compound_policy))
                     .wrap_err("Can't create log file configuration")?,
             ),
         )
@@ -98,4 +105,30 @@ fn log_level(level: &LogLevel) -> LevelFilter {
 
 fn roll_pattern(log_name: &str) -> String {
     format!("{}.{{}}.gz", log_name)
+}
+
+/// A trigger which rolls the log on a daily basis.
+#[derive(Debug)]
+struct DailyTrigger {
+    next_millis: std::sync::atomic::AtomicI64,
+}
+
+impl DailyTrigger {
+    /// Returns a new trigger which rolls the log daily at midnight.
+    fn new() -> Self {
+        let now = chrono::Local::now();
+        let next = now.date().succ().and_hms(0, 0, 0);
+        Self { next_millis: std::sync::atomic::AtomicI64::new(next.timestamp_millis()) }
+    }
+}
+
+impl Trigger for DailyTrigger {
+    fn trigger(&self, _: &LogFile) -> anyhow::Result<bool> {
+        let now = chrono::Local::now();
+        let next = now.date().succ().and_hms(0, 0, 0);
+        let last_millis = self
+            .next_millis
+            .swap(next.timestamp_millis(), std::sync::atomic::Ordering::AcqRel);
+        Ok(now.timestamp_millis() >= last_millis)
+    }
 }

--- a/adlu-proxy/src/logging.rs
+++ b/adlu-proxy/src/logging.rs
@@ -67,7 +67,7 @@ pub fn init(logging: &Logging) -> Result<()> {
             .build(&pattern, window_size)
             .map_err(|err| eyre!("Can't build log rotation config: {:?}", err))?;
         let compound_policy = if let LogRotationType::Sized = logging.rotate_type {
-            let size_limit = 1024 * logging.max_size_kb;
+            let size_limit = 1024 * logging.rotate_size_kb;
             let size_trigger = SizeTrigger::new(size_limit as u64);
             CompoundPolicy::new(Box::new(size_trigger), Box::new(fixed_window_roller))
         } else {

--- a/adlu-proxy/src/main.rs
+++ b/adlu-proxy/src/main.rs
@@ -19,12 +19,12 @@ released.  That license is reproduced here in the LICENSE-MIT file.
 use clap::Parser;
 
 use adlu_base::get_first_interrupt;
-use adlu_proxy::cli::ProxyArgs;
+use adlu_proxy::cli::{Command, ProxyArgs};
 use adlu_proxy::settings;
 
 #[tokio::main]
 async fn main() {
-    let args: ProxyArgs = ProxyArgs::parse();
+    let mut args: ProxyArgs = ProxyArgs::parse();
     // if we have a valid config, proceed, else update the config
     if let Ok(settings) = settings::load_config_file(&args) {
         let stop_signal = get_first_interrupt();
@@ -33,8 +33,10 @@ async fn main() {
             std::process::exit(1);
         }
     } else {
-        eprintln!("Couldn't read the configuration file, creating a new one...");
-        if let Err(err) = settings::update_config_file(None, &args.config_file) {
+        eprintln!("Configuration file missing or out of date...");
+        args.cmd = Command::Configure { repair: false };
+        let settings = settings::load_config_file(&args);
+        if let Err(err) = settings::update_config_file(settings.ok().as_ref(), &args) {
             eprintln!("Failed to create config file: {}", err);
             std::process::exit(1);
         }

--- a/adlu-proxy/src/main.rs
+++ b/adlu-proxy/src/main.rs
@@ -33,9 +33,12 @@ async fn main() {
             std::process::exit(1);
         }
     } else {
-        eprintln!("Configuration file missing or out of date...");
-        args.cmd = Command::Configure { repair: false };
+        if !matches!(args.cmd, Command::Configure { .. }) {
+            eprintln!("The proxy cannot run without a valid configuration file.");
+            args.cmd = Command::Configure { repair: false };
+        }
         let settings = settings::load_config_file(&args);
+        eprintln!("Please answer the questions to update your configuration file...");
         if let Err(err) = settings::update_config_file(settings.ok().as_ref(), &args) {
             eprintln!("Failed to create config file: {}", err);
             std::process::exit(1);

--- a/adlu-proxy/src/settings.rs
+++ b/adlu-proxy/src/settings.rs
@@ -893,8 +893,12 @@ mod test {
         let settings = load_config_file(&args).expect("Can't load config");
         update_config_file(Some(&settings), &args).expect("Can't update config");
         let updated = std::fs::read_to_string(cfg).expect("Can't read updated");
+        // canonicalize line endings
+        let updated = updated.replace("\r\n", "\n");
+        // skip the first line that has the proxy version
         let updated_rest = &updated[updated.find('\n').expect("No newline")..];
         let expected = std::fs::read_to_string(after).expect("Can't read expected");
+        let expected = expected.replace("\r\n", "\n");
         let expected_rest = &expected[expected.find('\n').expect("No newline")..];
         assert_eq!(updated_rest, expected_rest)
     }

--- a/adlu-proxy/src/testing/mod.rs
+++ b/adlu-proxy/src/testing/mod.rs
@@ -52,8 +52,7 @@ async fn init_logging_and_cache() -> cache::Cache {
                 level: LogLevel::Debug,
                 destination: settings::LogDestination::File,
                 file_path: tempdir.join("proxy-log.log").to_str().unwrap().to_string(),
-                rotate_size_kb: 0,
-                rotate_count: 0,
+                ..Default::default()
             };
             logging::init(&logging).unwrap();
             shared_cache.log_initialized = true;

--- a/rsrc/configs/proxy-conf.toml.adobe
+++ b/rsrc/configs/proxy-conf.toml.adobe
@@ -1,0 +1,27 @@
+[proxy]
+mode = "cache"
+host = "127.0.0.1"
+port = "8080"
+ssl_port = "8443"
+remote_host = "https://lcs-cops-proxy.adobe.com"
+ssl = false
+
+[ssl]
+cert_path = "proxy-cert.pfx"
+cert_password = ""
+
+[logging]
+level = "off"
+destination = "console"
+file_path = "proxy-log.log"
+
+[cache]
+db_path = "proxy-cache.sqlite"
+
+[network]
+use_proxy = false
+proxy_host = "127.0.0.1"
+proxy_port = "8888"
+use_basic_auth = false
+proxy_username = ""
+proxy_password = ""

--- a/rsrc/configs/proxy-conf.toml.v0-no-rotate
+++ b/rsrc/configs/proxy-conf.toml.v0-no-rotate
@@ -1,0 +1,36 @@
+[proxy]
+db_path = "proxy-cache.sqlite"
+mode = "connected"
+host = "127.0.0.1"
+port = "8080"
+ssl_port = "8443"
+ssl = false
+
+[ssl]
+use_pfx = true
+pfx_path = "proxy-certkey"
+cert_path = "proxy-cert"
+key_path = "proxy-key"
+password = ""
+
+[frl]
+remote_host = "https://lcs-cops-proxy.adobe.com"
+
+[log]
+remote_host = "https://lcs-ulecs.adobe.io"
+
+[upstream]
+use_proxy = false
+proxy_protocol = "http"
+proxy_host = "127.0.0.1"
+proxy_port = "8888"
+use_basic_auth = false
+proxy_username = ""
+proxy_password = ""
+
+[logging]
+level = "info"
+destination = "file"
+file_path = "proxy-log.log"
+rotate_size_kb = 0
+rotate_count = 10

--- a/rsrc/configs/proxy-conf.toml.v0-rotate
+++ b/rsrc/configs/proxy-conf.toml.v0-rotate
@@ -1,0 +1,36 @@
+[proxy]
+db_path = "proxy-cache.sqlite"
+mode = "connected"
+host = "127.0.0.1"
+port = "8080"
+ssl_port = "8443"
+ssl = false
+
+[ssl]
+use_pfx = true
+pfx_path = "proxy-certkey"
+cert_path = "proxy-cert"
+key_path = "proxy-key"
+password = ""
+
+[frl]
+remote_host = "https://lcs-cops-proxy.adobe.com"
+
+[log]
+remote_host = "https://lcs-ulecs.adobe.io"
+
+[upstream]
+use_proxy = false
+proxy_protocol = "http"
+proxy_host = "127.0.0.1"
+proxy_port = "8888"
+use_basic_auth = false
+proxy_username = ""
+proxy_password = ""
+
+[logging]
+level = "info"
+destination = "file"
+file_path = "proxy-log.log"
+rotate_size_kb = 1024
+rotate_count = 10

--- a/rsrc/configs/proxy-conf.toml.v1-no-rotate
+++ b/rsrc/configs/proxy-conf.toml.v1-no-rotate
@@ -1,0 +1,40 @@
+proxy_version = "1.1.0-alpha.1"
+settings_version = 1
+
+[proxy]
+db_path = "proxy-cache.sqlite"
+mode = "connected"
+host = "127.0.0.1"
+port = "8080"
+ssl_port = "8443"
+ssl = false
+
+[ssl]
+use_pfx = true
+pfx_path = "proxy-certkey"
+cert_path = "proxy-cert"
+key_path = "proxy-key"
+password = ""
+
+[frl]
+remote_host = "https://lcs-cops-proxy.adobe.com"
+
+[log]
+remote_host = "https://lcs-ulecs.adobe.io"
+
+[upstream]
+use_proxy = false
+proxy_protocol = "http"
+proxy_host = "127.0.0.1"
+proxy_port = "8888"
+use_basic_auth = false
+proxy_username = ""
+proxy_password = ""
+
+[logging]
+level = "info"
+destination = "file"
+file_path = "proxy-log.log"
+rotate_type = "none"
+rotate_size_kb = 100
+rotate_count = 10

--- a/rsrc/configs/proxy-conf.toml.v1-rotate
+++ b/rsrc/configs/proxy-conf.toml.v1-rotate
@@ -1,0 +1,40 @@
+proxy_version = "1.1.0-alpha.1"
+settings_version = 1
+
+[proxy]
+db_path = "proxy-cache.sqlite"
+mode = "connected"
+host = "127.0.0.1"
+port = "8080"
+ssl_port = "8443"
+ssl = false
+
+[ssl]
+use_pfx = true
+pfx_path = "proxy-certkey"
+cert_path = "proxy-cert"
+key_path = "proxy-key"
+password = ""
+
+[frl]
+remote_host = "https://lcs-cops-proxy.adobe.com"
+
+[log]
+remote_host = "https://lcs-ulecs.adobe.io"
+
+[upstream]
+use_proxy = false
+proxy_protocol = "http"
+proxy_host = "127.0.0.1"
+proxy_port = "8888"
+use_basic_auth = false
+proxy_username = ""
+proxy_password = ""
+
+[logging]
+level = "info"
+destination = "file"
+file_path = "proxy-log.log"
+rotate_type = "sized"
+rotate_size_kb = 1024
+rotate_count = 10

--- a/rsrc/install/ubuntu/install-adlu-proxy-release.sh
+++ b/rsrc/install/ubuntu/install-adlu-proxy-release.sh
@@ -4,7 +4,7 @@
 # directory should be the parent of a newly-created adlu-proxy directory
 # that contains the running server.  The script makes the adlu-proxy directory,
 # downloads the ubuntu binary to that directory, and then runs the proxy
-# for you to create your configuration file.
+# to update (or create via interview) the proxy configuration file.
 #
 # You need to invoke the script with release tag you want to download;
 # for example, v1.0.0-alpha.2 or v1.0.1
@@ -38,5 +38,5 @@ then
     exit 1
   fi
   echo "Proxy is installed.  Configuring..."
-  exec ./adlu-proxy configure
+  exec ./adlu-proxy configure --repair
 fi


### PR DESCRIPTION
This PR fixes #10, adding the ability to rotate logs at midnight (local server time) every day.

Because this changes the format of the config file, this PR also introduces a version attribute into the config, and provides for automatic migration of older configs to the current format with the `aclu-proxy configure --repair` flag.
