### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: publish
 
 on:
-  workflow-dispatch:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,12 @@
 name: publish
 
 on:
+  workflow-dispatch:
   push:
     tags:
       - 'v*'
+      - 'proxy-v*'
+      - 'decoder-v*'
 
 jobs:
   publish:


### PR DESCRIPTION
Make sure proxy-specific and decoder-specific releases get their artifacts built and published.

Also allow manual triggering of artifact builds.